### PR TITLE
Return an error to the callback on 404 responses

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ HttpSource.prototype.getTile = function(z, x, y, callback) {
       return callback(null, body, rspHeaders);
 
     case 404:
-      return callback();
+      return callback(new Error('Tile does not exist'));
 
     default:
       return callback(new Error("Upstream error: " + rsp.statusCode));


### PR DESCRIPTION
Without this, tilelive.copytask will try accessing data.solid with data being null, and then crash out.

The copytask is happy to skip missing tiles if it receives an error with a particular format - see https://github.com/mapbox/tilelive.js/blob/f06db2bb9a1257c40894051e2926a97e536d988a/lib/copytask.js#L177 .
