### PR TITLE
Add retry support using node-backoff.

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "author": "Seth Fitzsimmons <seth@mojodna.net>",
   "license": "MIT",
   "dependencies": {
-    "request": "^2.34.0"
+    "request": "^2.34.0",
+    "backoff": "~2.3.0"
   },
   "peerDependencies": {
     "tilelive": "^4.5.3",


### PR DESCRIPTION
@rcoup - I like this patch, though it seems like it needs to distinguish between 4xx responses and internal/upstream errors in order to not repeatedly hammer URLs that will never work.  How's it been working for you?

https://github.com/mapbox/tilelive.js/pull/66#issuecomment-40444919 should help address that, as the 404 condition won't pass an error forward.

Thoughts?