### PR TITLE
Request gzip content-encoding

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,7 +58,8 @@ module.exports = function(tilelive, options) {
         uri: uri,
         encoding: null,
         headers: headers,
-        timeout: 30e3
+        timeout: 30e3,
+        gzip: true
       }, function(err, rsp, body) {
         if (operation.retry(err)) {
           debug("Failed %s after %d attempts:", url.format(uri), currentAttempt, err);


### PR DESCRIPTION
[Some tile servers](https://github.com/mapbox/mapbox-gl-js/issues/1567#issuecomment-232721136) ignore 'accept-encoding' and return gzip encoded content whatever. In that case `tilelive-http` does not decompress the data, and leads to hours of head-scratching.