### PR TITLE
v0.12.0: Use "Accept-encoding: gzip, deflate"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changes
 
+## v0.12.0 - 11/01/16
+
+* Add "Accept-encoding: gzip, deflate" as the default header, and the option.acceptEncoding
+  to override it. This supports correctly configured MVT services like maps.wikimedia.org
+
 ## v0.11.3 - 7/24/16
 
 * Revert explicit request for `gzip`ed content, as MVT PBFs are intended to be

--- a/index.js
+++ b/index.js
@@ -38,9 +38,11 @@ module.exports = function(tilelive, options) {
   options = options || {};
   options.retry = "retry" in options ? options.retry : false;
   options.userAgent = options.userAgent || process.env.TILELIVE_USER_AGENT || [NAME, VERSION].join("/");
+  options.acceptEncoding = options.acceptEncoding || 'gzip, deflate';
 
   var headers = {
-        "User-Agent": options.userAgent
+        "User-Agent": options.userAgent,
+        "Accept-encoding": options.acceptEncoding
       },
       retryOptions = {
         factor: 1.71023

--- a/package.json
+++ b/package.json
@@ -1,9 +1,12 @@
 {
-  "name": "tilelive-http",
+  "name": "@kartotherian/tilelive-http",
   "version": "0.12.0",
-  "description": "HTTP source for tilelive",
+  "description": "HTTP source for tilelive - with Kartotherian header compression customizations",
   "main": "index.js",
   "author": "Seth Fitzsimmons <seth@mojodna.net>",
+  "contributors": [
+    "Yuri Astrakhan <YuriAstrakhan@gmail.com>"
+  ],
   "license": "MIT",
   "dependencies": {
     "debug": "^2.2.0",
@@ -16,11 +19,11 @@
     "tilelive": "*",
     "tilejson": ">= 0.6.4"
   },
-  "homepage": "https://github.com/mojodna/tilelive-http",
-  "bugs": "https://github.com/mojodna/tilelive-http/issues",
+  "homepage": "https://github.com/kartotherian/tilelive-http",
+  "bugs": "https://github.com/kartotherian/tilelive-http/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/mojodna/tilelive-http"
+    "url": "https://github.com/kartotherian/tilelive-http"
   },
   "files": [
     "index.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kartotherian/tilelive-http",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "HTTP source for tilelive - with Kartotherian header compression customizations",
   "main": "index.js",
   "author": "Seth Fitzsimmons <seth@mojodna.net>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tilelive-http",
-  "version": "0.11.3",
+  "version": "0.12.0",
   "description": "HTTP source for tilelive",
   "main": "index.js",
   "author": "Seth Fitzsimmons <seth@mojodna.net>",


### PR DESCRIPTION
Add "Accept-encoding: gzip, deflate" as the default header, and the option.acceptEncoding
to override it. This supports correctly configured MVT services like maps.wikimedia.org

From https://github.com/mojodna/tilelive-http/issues/17

Sadly MVT compression serving is horribly broken, and any request for a Mapbox's tile always returns it compressed, even if Accepted-Header does not specify that. While it works ok in the browser (browser always add that header, and always auto-decompresses it for you), it is broken for tilelive-http for any correctly configured tile sources. For example, asking for a https://maps.wikimedia.org/pbf/4/3/5.pbf would return a compressed or non-compressed pbf based on the accept-header, but Mapbox would ALWAYS return it compressed.

This means that if I use tilelive-http in Kartotherian, it gets back uncompressed data as requested, and tilelive-vector cannot process it correctly.

Please re-enable gzip, or at least make it default with an option to disable it.